### PR TITLE
Fix to metacorr UI: Assign moderator button

### DIFF
--- a/jamovi/metacorr.u.yaml
+++ b/jamovi/metacorr.u.yaml
@@ -29,13 +29,13 @@ children:
             name: slab
             maxItemCount: 1
             isTarget: true
-          - type: TargetLayoutBox
-            label: Moderator
-            children:
-              - type: VariablesListBox
-                name: moderatorcor
-                maxItemCount: 1
-                isTarget: true
+      - type: TargetLayoutBox
+        label: Moderator (optional)
+        children:
+          - type: VariablesListBox
+            name: moderatorcor
+            maxItemCount: 1
+            isTarget: true
   - type: LayoutBox
     margin: large
     children:


### PR DESCRIPTION
Again, don't feel like you have to merge this, this was just the easiest way to point this out.

This fixes this:

![screen shot 2017-11-11 at 19 40 20](https://user-images.githubusercontent.com/3240247/32687897-94ed4e28-c71a-11e7-9316-ba76fc1fa0a1.png)

